### PR TITLE
Add Rubocop linter step to test job

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,5 +31,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run tests
+    - name: Run linter
+      run: bundle exec rake rubocop
+    - name: Run unit tests
       run: bundle exec rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   Exclude:
     - 'bin/**/*'
     - 'bundle/**/*'
+    - 'vendor/**/*'
     - '*.gemspec'
   NewCops: enable
 


### PR DESCRIPTION
Rubocop is configured to lint the gem code and spec tests
