### PR TITLE
Bundle config user settings

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,4 +1,0 @@
----
-BUNDLE_BIN: "bin"
-BUNDLE_DISABLE_SHARED_GEMS: "true"
-BUNDLE_PATH: "./bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-/bin/*
-!/bin/console
-!/bin/setup
-/bundle/
+/.bundle/
 /.yardoc
 /_yardoc/
 /coverage/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,9 +3,9 @@ require:
   - rubocop-rspec
 AllCops:
   Exclude:
-    - 'bin/**/*'
-    - 'bundle/**/*'
+    - 'bin/*'
     - 'vendor/**/*'
+    - '.bundle/**/*'
     - '*.gemspec'
   NewCops: enable
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ puts superset.latest_version
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. Run `bundle exec rubocop` to run the linter. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
+Note that by default, Bundler will attempt to install gems to the system, e.g. `/usr/bin`, `/usr/share`, which requires elevated access and can interfere with files that are managed by the system's package manager. This behaviour can be overridden by creating the file `.bundle/config` and adding the following line:
+```
+BUNDLE_PATH: "./.bundle"
+```
+When you run `bin/setup` or `bundle install`, all gems will be installed inside the .bundle directory of this project.
+
+To make this behaviour a default for all gem projects, the above line can be added to the user's bundle config file in their home directory (`~/.bundle/config`)
+
 ## Contributing
 
 Bug reports and pull requests are welcome on [GitHub](https://github.com/liger1978/getv).

--- a/getv.gemspec
+++ b/getv.gemspec
@@ -20,7 +20,10 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f|
+      f.match(%r{^(test|spec|features|bin)/}) or
+        f.match(%r{^(\.|Rakefile|Gemfile|getv.gemspec)})
+    }
   end
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
User bundle config (and corresponding gitlab and rubocop amendments) removed as they can be specified in user's own bundle config (and git config). Excluded .bundle so that user can use that path for bundle files
- Spec file now only builds gems with necessary files (ignoring ci and development files)