### PR TITLE
autopaginate docker tags by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in getv.gemspec
 gemspec
 
-gem 'docker_registry2', ['>= 1.10.1', '< 2.0.0']
+gem 'docker_registry2', ['>= 1.11.0', '< 2.0.0']
 gem 'gli', '~> 2.20'
 gem 'irb', '~> 1.4'
 gem 'nokogiri', '~> 1.13'

--- a/lib/getv/package/docker.rb
+++ b/lib/getv/package/docker.rb
@@ -6,7 +6,7 @@ module Getv
     class Docker < Package
       def initialize(name, opts = {})
         opts = defaults.merge(opts)
-        opts = { user: nil, password: nil }.merge(opts)
+        opts = { user: nil, password: nil, auto_paginate: true }.merge(opts)
         opts = docker_defaults(name).merge(opts)
         super name, opts
       end
@@ -40,7 +40,7 @@ module Getv
         require 'docker_registry2'
         retries ||= 0
         docker = DockerRegistry2.connect(opts[:url], docker_opts)
-        docker.tags("#{opts[:owner]}/#{opts[:repo]}")['tags'] || []
+        docker.tags("#{opts[:owner]}/#{opts[:repo]}", auto_paginate: opts[:auto_paginate])['tags'] || []
       rescue DockerRegistry2::NotFound
         []
       rescue StandardError => e

--- a/spec/getv/package/docker_spec.rb
+++ b/spec/getv/package/docker_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe Getv::Package::Docker, :vcr do
   let :default_opts do
     {
+      auto_paginate: true,
       latest_version: nil,
       password: nil,
       proxy: nil,


### PR DESCRIPTION
By default, `docker_registry2` doesn't auto paginate but rather returns a link to the next page. Enabling seems to work with registries that implement pagination.

Newer version of getv supports quay.io's nonstandard tag pagination.